### PR TITLE
remove convert-source-map dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,8 +18,5 @@
     "css-to-string",
     "to-string"
   ],
-  "license": "MIT",
-  "dependencies": {
-    "convert-source-map": "^1.3.0"
-  }
+  "license": "MIT"
 }

--- a/src/css-with-mapping.js
+++ b/src/css-with-mapping.js
@@ -20,14 +20,19 @@ module.exports.pitch = function (remainingRequest) {
 };
 
 function encode(content) {
+    function convertSourceMapToComment(sourcemap){
+        var base64 =  new Buffer(JSON.stringify(sourcemap)).toString('base64');
+        var data = 'sourceMappingURL=data:application/json;charset=utf-8;base64,' + base64;
+        return '/*# ' + data + ' */'
+    }
+
     var cssObject = content[0];
     var cssContent = cssObject[1] || '';
     var cssMapping = cssObject[3];
     if (!cssMapping) {
         return cssContent;
     }
-    var convertSourceMap = require('convert-source-map');
-    var sourceMapping = convertSourceMap.fromObject(cssMapping).toComment({multiline: true});
+    var sourceMapping = convertSourceMapToComment(cssMapping);
     var sourceURLs = cssMapping.sources.map(function (source) {
         return '/*# sourceURL=' + cssMapping.sourceRoot + source + ' */'
     });


### PR DESCRIPTION
the loader is not working under webpack 2.2.0/ubuntu 14.04 due to this error:

```
ERROR in ./~/convert-source-map/index.js
Module not found: Error: Can't resolve 'fs' in '*****/node_modules/convert-source-map'
 @ ./~/convert-source-map/index.js 2:9-22
```

the issue is solved by making these changes (removed the convert-source-map dependency)